### PR TITLE
Add draft archive control with hover and swipe gestures

### DIFF
--- a/app/components/chat/ChatDraftsList.vue
+++ b/app/components/chat/ChatDraftsList.vue
@@ -13,15 +13,21 @@ interface DraftEntry {
 interface Props {
   draftsPending: boolean
   contentEntries: DraftEntry[]
+  archivingDraftId?: string | null
 }
 
 const props = defineProps<Props>()
 
 const emit = defineEmits<{
   openWorkspace: [entry: DraftEntry]
+  archiveEntry: [entry: DraftEntry]
 }>()
 
 const activeTab = ref(0)
+
+const swipeState = ref<{ id: string, startX: number, startY: number } | null>(null)
+const SWIPE_THRESHOLD = 50
+const SWIPE_VERTICAL_THRESHOLD = 30
 
 const tabs = [
   { label: 'Drafts', value: 0 },
@@ -49,6 +55,37 @@ const handleOpenWorkspace = (entry: DraftEntry) => {
   emit('openWorkspace', entry)
 }
 
+const handleArchiveEntry = (entry: DraftEntry) => {
+  emit('archiveEntry', entry)
+}
+
+const onTouchStart = (entry: DraftEntry, event: TouchEvent) => {
+  const touch = event.touches?.[0]
+  if (!touch)
+    return
+
+  swipeState.value = {
+    id: entry.id,
+    startX: touch.clientX,
+    startY: touch.clientY
+  }
+}
+
+const onTouchEnd = (entry: DraftEntry, event: TouchEvent) => {
+  if (!swipeState.value || swipeState.value.id !== entry.id)
+    return
+
+  const touch = event.changedTouches?.[0]
+  if (!touch)
+    return
+
+  const deltaX = touch.clientX - swipeState.value.startX
+  const deltaY = touch.clientY - swipeState.value.startY
+
+  if (deltaX < -SWIPE_THRESHOLD && Math.abs(deltaY) < SWIPE_VERTICAL_THRESHOLD)
+    handleArchiveEntry(entry)
+}
+
 const formatUpdatedAt = (date: Date | null) => {
   if (!date) {
     return '—'
@@ -73,44 +110,63 @@ const formatUpdatedAt = (date: Date | null) => {
       v-if="hasFilteredContent"
       class="divide-y divide-muted-200/60"
     >
-      <button
+      <div
         v-for="entry in filteredEntries"
         :key="entry.id"
-        type="button"
-        class="w-full text-left py-4 px-1 space-y-2 hover:bg-muted/30 transition-colors"
-        @click="handleOpenWorkspace(entry)"
+        class="group relative w-full"
+        @touchstart.passive="onTouchStart(entry, $event)"
+        @touchend.passive="onTouchEnd(entry, $event)"
       >
-        <div class="flex items-center justify-between gap-3">
-          <p class="font-medium leading-tight truncate">
-            {{ entry.title }}
-          </p>
-          <UBadge
+        <button
+          type="button"
+          class="w-full text-left py-4 pr-12 pl-1 space-y-2 hover:bg-muted/30 transition-colors"
+          @click="handleOpenWorkspace(entry)"
+        >
+          <div class="flex items-center justify-between gap-3">
+            <p class="font-medium leading-tight truncate">
+              {{ entry.title }}
+            </p>
+            <UBadge
+              color="neutral"
+              variant="soft"
+              class="capitalize"
+            >
+              {{ entry.status || 'draft' }}
+            </UBadge>
+          </div>
+          <div class="text-xs text-muted-500 flex flex-wrap items-center gap-1">
+            <span>{{ formatUpdatedAt(entry.updatedAt) }}</span>
+            <span>·</span>
+            <span class="capitalize">
+              {{ entry.contentType || 'content' }}
+            </span>
+            <span>·</span>
+            <span class="font-mono text-[11px] text-muted-600 truncate">
+              {{ entry.id }}
+            </span>
+            <span>·</span>
+            <span class="text-emerald-500 dark:text-emerald-400">
+              +{{ entry.additions ?? 0 }}
+            </span>
+            <span class="text-rose-500 dark:text-rose-400">
+              -{{ entry.deletions ?? 0 }}
+            </span>
+          </div>
+        </button>
+        <div class="absolute inset-y-0 right-0 flex items-center pr-2">
+          <UButton
             color="neutral"
-            variant="soft"
-            class="capitalize"
-          >
-            {{ entry.status || 'draft' }}
-          </UBadge>
+            variant="ghost"
+            size="xs"
+            icon="i-lucide-archive"
+            class="opacity-0 transition-opacity group-hover:opacity-100 focus:opacity-100 hidden sm:flex"
+            :disabled="archivingDraftId === entry.id"
+            :loading="archivingDraftId === entry.id"
+            aria-label="Archive draft"
+            @click.stop="handleArchiveEntry(entry)"
+          />
         </div>
-        <div class="text-xs text-muted-500 flex flex-wrap items-center gap-1">
-          <span>{{ formatUpdatedAt(entry.updatedAt) }}</span>
-          <span>·</span>
-          <span class="capitalize">
-            {{ entry.contentType || 'content' }}
-          </span>
-          <span>·</span>
-          <span class="font-mono text-[11px] text-muted-600 truncate">
-            {{ entry.id }}
-          </span>
-          <span>·</span>
-          <span class="text-emerald-500 dark:text-emerald-400">
-            +{{ entry.additions ?? 0 }}
-          </span>
-          <span class="text-rose-500 dark:text-rose-400">
-            -{{ entry.deletions ?? 0 }}
-          </span>
-        </div>
-      </button>
+      </div>
     </div>
     <div
       v-else

--- a/app/components/chat/QuillioWidget.vue
+++ b/app/components/chat/QuillioWidget.vue
@@ -99,6 +99,7 @@ const verifiedDraftLimit = computed(() => parseDraftLimitValue(runtimeConfig.pub
 const activeWorkspaceId = ref<string | null>(null)
 const workspaceDetail = shallowRef<any | null>(null)
 const workspaceLoading = ref(false)
+const archivingDraftId = ref<string | null>(null)
 const draftQuotaState = useState<DraftQuotaUsagePayload | null>('draft-quota-usage', () => null)
 const workspacePayloadCache = useState<Record<string, { payload: any | null, timestamp: number }>>('workspace-payload-cache', () => ({}))
 const WORKSPACE_CACHE_TTL_MS = 30_000
@@ -691,6 +692,43 @@ const openWorkspace = async (entry: { id: string, slug?: string | null }) => {
   await activateWorkspace(entry.id)
 }
 
+const archiveDraft = async (entry: { id: string, title?: string | null }) => {
+  if (!entry?.id || archivingDraftId.value === entry.id)
+    return
+
+  archivingDraftId.value = entry.id
+
+  try {
+    await $fetch(`/api/chat/drafts/${entry.id}/archive`, {
+      method: 'POST'
+    })
+
+    if (activeWorkspaceId.value === entry.id) {
+      await activateWorkspace(null)
+      resetConversation()
+    }
+
+    await refreshDrafts()
+
+    toast.add({
+      title: 'Draft archived',
+      description: entry.title || 'Draft moved to archive.',
+      color: 'neutral',
+      icon: 'i-lucide-archive'
+    })
+  } catch (error: any) {
+    const message = error?.data?.statusMessage || error?.statusMessage || 'Failed to archive draft'
+    toast.add({
+      title: 'Archive failed',
+      description: message,
+      color: 'error',
+      icon: 'i-lucide-alert-triangle'
+    })
+  } finally {
+    archivingDraftId.value = null
+  }
+}
+
 const resetConversation = () => {
   prompt.value = ''
   linkedSources.value = []
@@ -1194,7 +1232,9 @@ if (import.meta.client) {
         <ChatDraftsList
           :drafts-pending="draftsPending"
           :content-entries="contentEntries"
+          :archiving-draft-id="archivingDraftId"
           @open-workspace="openWorkspace"
+          @archive-entry="archiveDraft"
         />
       </div>
     </div>

--- a/server/api/chat/drafts/[id]/archive.post.ts
+++ b/server/api/chat/drafts/[id]/archive.post.ts
@@ -1,0 +1,49 @@
+import { and, eq } from 'drizzle-orm'
+import { createError, getRouterParams } from 'h3'
+import * as schema from '~~/server/database/schema'
+import { requireAuth } from '~~/server/utils/auth'
+import { getDB } from '~~/server/utils/db'
+import { requireActiveOrganization } from '~~/server/utils/organization'
+import { validateUUID } from '~~/server/utils/validation'
+
+export default defineEventHandler(async (event) => {
+  const user = await requireAuth(event, { allowAnonymous: true })
+  const { organizationId } = await requireActiveOrganization(event, user.id)
+  const db = getDB()
+
+  const { id } = getRouterParams(event)
+  const contentId = validateUUID(id, 'id')
+
+  const [content] = await db
+    .select({
+      id: schema.content.id,
+      status: schema.content.status
+    })
+    .from(schema.content)
+    .where(and(
+      eq(schema.content.id, contentId),
+      eq(schema.content.organizationId, organizationId)
+    ))
+    .limit(1)
+
+  if (!content) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'Draft not found'
+    })
+  }
+
+  if (content.status === 'archived') {
+    return { success: true, status: 'archived' }
+  }
+
+  await db
+    .update(schema.content)
+    .set({ status: 'archived' })
+    .where(and(
+      eq(schema.content.id, contentId),
+      eq(schema.content.organizationId, organizationId)
+    ))
+
+  return { success: true, status: 'archived' }
+})


### PR DESCRIPTION
## Summary
- add archive endpoint for chat drafts
- expose archive control in draft list with hover and swipe interactions
- wire list actions to refresh workspace state when drafts are archived


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932c1586e0c8321b74ab9f1d0af6c2e)