### PR TITLE
Align theme tokens for layouts and chat surfaces

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -12,7 +12,7 @@
   }
 
   body {
-    @apply bg-neutral-100 dark:bg-neutral-950;
+    @apply bg-background text-foreground;
   }
 
   /* Mobile-safe full height utility */

--- a/app/components/chat/ChatDraftsList.vue
+++ b/app/components/chat/ChatDraftsList.vue
@@ -122,7 +122,7 @@ const formatUpdatedAt = (date: Date | null) => {
 
     <div
       v-if="hasFilteredContent"
-      class="divide-y divide-white/10"
+      class="divide-y divide-muted-200/80 dark:divide-muted-800/70"
     >
       <div
         v-for="entry in filteredEntries"
@@ -133,11 +133,11 @@ const formatUpdatedAt = (date: Date | null) => {
       >
         <button
           type="button"
-          class="w-full text-left py-4 pr-12 pl-1 space-y-2 hover:bg-muted/30 transition-colors text-sm"
+          class="w-full text-left py-4 pr-12 pl-1 space-y-2 hover:bg-muted/30 transition-colors text-sm text-foreground"
           @click="handleOpenWorkspace(entry)"
         >
           <div class="flex items-center justify-between gap-3">
-            <p class="text-sm font-semibold leading-tight truncate text-white">
+            <p class="text-sm font-semibold leading-tight truncate">
               {{ entry.title }}
             </p>
             <UBadge

--- a/app/components/chat/PromptComposer.vue
+++ b/app/components/chat/PromptComposer.vue
@@ -230,9 +230,9 @@ useEventListener(textareaRef, 'blur', () => {
   >
     <div
       v-if="mentionPanelVisible"
-      class="absolute bottom-full mb-2 left-0 w-full max-w-md rounded-lg border border-neutral-200/70 dark:border-neutral-800/60 bg-background shadow-lg z-20"
+      class="absolute bottom-full mb-2 left-0 w-full max-w-md rounded-lg border border-muted-200/80 dark:border-muted-800/70 bg-background shadow-lg z-20"
     >
-      <div class="px-3 py-2 border-b border-neutral-200/70 dark:border-neutral-800/60">
+      <div class="px-3 py-2 border-b border-muted-200/80 dark:border-muted-800/70">
         <p class="text-xs uppercase tracking-wide text-muted-500">
           Mention a section
         </p>
@@ -250,7 +250,7 @@ useEventListener(textareaRef, 'blur', () => {
           :key="section.id"
           type="button"
           class="w-full text-left px-3 py-2 rounded-md transition-colors"
-          :class="mentionHighlightedIndex === index ? 'bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-100' : 'hover:bg-neutral-100/70 dark:hover:bg-neutral-800/70'"
+          :class="mentionHighlightedIndex === index ? 'bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-100' : 'hover:bg-muted/40 dark:hover:bg-muted/60'"
           role="option"
           :aria-selected="mentionHighlightedIndex === index"
           :data-highlighted="mentionHighlightedIndex === index"

--- a/app/components/chat/QuillioWidget.vue
+++ b/app/components/chat/QuillioWidget.vue
@@ -1014,7 +1014,7 @@ if (import.meta.client) {
       :ui="{
         overlay: 'bg-black/60 backdrop-blur-sm',
         container: 'max-w-sm mx-auto',
-        base: 'bg-neutral-900 text-white rounded-2xl shadow-2xl',
+        base: 'bg-background text-foreground rounded-2xl shadow-2xl border border-muted-200/80 dark:border-muted-800/70',
         header: 'hidden',
         body: 'p-4 space-y-4',
         footer: 'hidden'
@@ -1024,7 +1024,7 @@ if (import.meta.client) {
     >
       <template #body>
         <div class="space-y-3">
-          <p class="text-sm text-white/80 whitespace-pre-wrap max-h-48 overflow-y-auto">
+          <p class="text-sm text-muted-700 dark:text-muted-200 whitespace-pre-wrap max-h-48 overflow-y-auto">
             {{ messageActionSheetTarget ? getMessageText(messageActionSheetTarget) : '' }}
           </p>
           <div class="flex flex-col gap-2">

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -49,8 +49,8 @@ provide('setHeaderTitle', (title: string | null) => {
 
 <template>
   <div class="min-h-screen flex flex-col bg-background text-foreground">
-    <header class="border-b border-neutral-200/70 dark:border-neutral-800/60 bg-background/90 backdrop-blur-sm">
-      <div class="px-4 py-3 flex items-center justify-between gap-3 max-w-3xl mx-auto w-full">
+    <header class="border-b border-muted-200/80 dark:border-muted-800/70 bg-background/90 backdrop-blur-sm">
+      <div class="px-4 py-3 flex items-center justify-between gap-3 max-w-3xl mx-auto w-full text-foreground">
         <div class="flex-1 flex items-center justify-start min-w-0">
           <slot name="header-title">
             <h1

--- a/app/layouts/workspace.vue
+++ b/app/layouts/workspace.vue
@@ -11,8 +11,8 @@ useHead(() => ({
 </script>
 
 <template>
-  <div class="min-h-screen flex flex-col bg-background">
-    <header class="sticky top-0 z-40 border-b border-neutral-200/70 dark:border-neutral-800/60 bg-background/95 backdrop-blur-sm shadow-sm">
+  <div class="min-h-screen flex flex-col bg-background text-foreground">
+    <header class="sticky top-0 z-40 border-b border-muted-200/80 dark:border-muted-800/70 bg-background/95 backdrop-blur-sm shadow-sm">
       <div
         class="px-4 py-4 max-w-3xl mx-auto w-full"
       >
@@ -96,7 +96,7 @@ useHead(() => ({
             </div>
             <div
               v-if="workspaceHeader.tabs"
-              class="w-full border-b border-neutral-200/60 dark:border-neutral-800/60"
+              class="w-full border-b border-muted-200/80 dark:border-muted-800/70"
             >
               <UTabs
                 :items="workspaceHeader.tabs.items"


### PR DESCRIPTION
## Summary
- update default and workspace layouts to rely on muted Nuxt UI borders and text for theme parity
- refresh chat UI surfaces (draft list, prompt mention panel, modal) to remove hardcoded dark-mode colors
- switch global body background/text to theme tokens for consistent light/dark rendering

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693392d6fcd8832185da07f237751e1c)