### PR TITLE
Add shared AI thinking indicator for draft progress

### DIFF
--- a/app/components/chat/ChatDraftsList.vue
+++ b/app/components/chat/ChatDraftsList.vue
@@ -15,9 +15,11 @@ interface Props {
   draftsPending: boolean
   contentEntries: DraftEntry[]
   archivingDraftId?: string | null
+  pendingMessage?: string
 }
 
 const props = defineProps<Props>()
+const pendingMessage = computed(() => props.pendingMessage?.trim() || 'Working on your draft...')
 
 const emit = defineEmits<{
   openWorkspace: [entry: DraftEntry]
@@ -175,7 +177,7 @@ const formatUpdatedAt = (date: Date | null) => {
               v-else
               class="flex items-center gap-2 text-primary-200 font-semibold capitalize"
             >
-              <span class="animate-pulse">Working</span>
+              <span class="animate-pulse">{{ pendingMessage }}</span>
               <UButton
                 color="neutral"
                 variant="ghost"

--- a/app/components/chat/QuillioWidget.vue
+++ b/app/components/chat/QuillioWidget.vue
@@ -5,6 +5,8 @@ import { CONTENT_TYPE_OPTIONS } from '#shared/constants/contentTypes'
 import { useClipboard, useDebounceFn } from '@vueuse/core'
 import { shallowRef } from 'vue'
 
+import { resolveAiThinkingIndicator } from '~/utils/aiThinkingIndicators'
+
 import BillingUpgradeModal from '~/components/billing/UpgradeModal.vue'
 import PromptComposer from './PromptComposer.vue'
 import QuotaLimitModal from './QuotaLimitModal.vue'
@@ -293,6 +295,11 @@ const isStreaming = computed(() => ['submitted', 'streaming'].includes(status.va
 const uiStatus = computed(() => status.value)
 const shouldShowWhatsNew = computed(() => !isWorkspaceActive.value && messages.value.length === 0)
 const THINKING_MESSAGE_ID = 'quillio-thinking-placeholder'
+const aiThinkingIndicator = computed(() => resolveAiThinkingIndicator({
+  status: status.value,
+  logs: logs.value,
+  fallbackMessage: 'Working on your draft...'
+}))
 const displayMessages = computed<ChatMessage[]>(() => {
   const baseMessages = messages.value.slice()
 
@@ -301,7 +308,7 @@ const displayMessages = computed<ChatMessage[]>(() => {
       baseMessages.push({
         id: THINKING_MESSAGE_ID,
         role: 'assistant',
-        parts: [{ type: 'text' as const, text: 'Quillio is thinking...' }],
+        parts: [{ type: 'text' as const, text: aiThinkingIndicator.value.message }],
         createdAt: new Date(),
         payload: { placeholder: true }
       })
@@ -1071,6 +1078,7 @@ if (import.meta.client) {
           :drafts-pending="draftsPending"
           :content-entries="contentEntries"
           :archiving-draft-id="archivingDraftId"
+          :pending-message="aiThinkingIndicator.message"
           @open-workspace="openWorkspace"
           @archive-entry="archiveDraft"
           @stop-entry="stopWorkingDraft"

--- a/app/utils/aiThinkingIndicators.ts
+++ b/app/utils/aiThinkingIndicators.ts
@@ -1,0 +1,86 @@
+export interface AiThinkingLogEntry {
+  type?: string | null
+  message?: string | null
+  createdAt?: string | Date | null
+}
+
+interface IndicatorPreset {
+  label: string
+  message: string
+}
+
+const PRESETS: Record<string, IndicatorPreset> = {
+  thinking: {
+    label: 'Thinking',
+    message: 'Analyzing your request...'
+  },
+  collecting: {
+    label: 'Collecting sources',
+    message: 'Collecting links and transcripts...'
+  },
+  drafting: {
+    label: 'Drafting',
+    message: 'Drafting content right now...'
+  },
+  updating: {
+    label: 'Updating',
+    message: 'Applying changes to your draft...'
+  },
+  saving: {
+    label: 'Saving',
+    message: 'Saving your draft and syncing sections...'
+  },
+  finishing: {
+    label: 'Finishing up',
+    message: 'Wrapping up the latest draft updates...'
+  }
+}
+
+const LOG_TYPE_TO_PRESET: Record<string, keyof typeof PRESETS> = {
+  source_detected: 'collecting',
+  content_generated: 'saving',
+  generation_complete: 'finishing',
+  section_patched: 'updating',
+  user_message: 'thinking'
+}
+
+const STATUS_TO_PRESET: Record<string, keyof typeof PRESETS> = {
+  submitted: 'thinking',
+  streaming: 'drafting'
+}
+
+function getLatestLog(logs?: AiThinkingLogEntry[] | null): AiThinkingLogEntry | null {
+  if (!Array.isArray(logs) || logs.length === 0)
+    return null
+
+  return logs.reduce<AiThinkingLogEntry | null>((latest, current) => {
+    const latestTime = latest?.createdAt ? new Date(latest.createdAt).getTime() : -Infinity
+    const currentTime = current?.createdAt ? new Date(current.createdAt).getTime() : -Infinity
+    return currentTime > latestTime ? current : latest
+  }, null)
+}
+
+export function resolveAiThinkingIndicator(input: {
+  status?: string | null
+  logs?: AiThinkingLogEntry[] | null
+  fallbackMessage?: string
+}): IndicatorPreset {
+  const latestLog = getLatestLog(input.logs)
+  const presetFromLog = latestLog?.type ? LOG_TYPE_TO_PRESET[(latestLog.type || '').toLowerCase()] : null
+
+  if (presetFromLog && PRESETS[presetFromLog])
+    return PRESETS[presetFromLog]
+
+  const presetFromStatus = input.status ? STATUS_TO_PRESET[(input.status || '').toLowerCase()] : null
+  if (presetFromStatus && PRESETS[presetFromStatus])
+    return PRESETS[presetFromStatus]
+
+  if (input.fallbackMessage) {
+    return {
+      label: 'Working',
+      message: input.fallbackMessage
+    }
+  }
+
+  return PRESETS.thinking
+}


### PR DESCRIPTION
## Summary
- add a reusable AI thinking indicator helper that normalizes status/log messages
- use the indicator to show meaningful placeholders in chat while streaming
- surface the same indicator text in the drafts list pending state instead of a generic label

## Testing
- (not run) pnpm lint *(pnpm/npm unavailable in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693396e548e083218a76e0e607f56275)